### PR TITLE
Compatibility with nibabel v5.0

### DIFF
--- a/wmaPyTools/analysisTools.py
+++ b/wmaPyTools/analysisTools.py
@@ -144,7 +144,7 @@ def endpointDispersionMapping(streamlines,referenceNifti,distanceParameter):
         currentSphere=wmaPyTools.roiTools.createSphere(distanceParameter, subjectSpaceTractCoords[iCoords,:], referenceNifti)
         
         #get the sphere coords in image space
-        currentSphereImgCoords = np.array(np.where(currentSphere.get_data())).T
+        currentSphereImgCoords = np.array(np.where(currentSphere.get_fdata())).T
         
         #find the roi coords which correspond to voxels within the streamline mask
         validCoords=list(set(list(tuple([tuple(e) for e in currentSphereImgCoords]))) & set(imgSpaceTractVoxels))
@@ -604,7 +604,7 @@ def endpointDispersionMapping_Bootstrap(streamlines,referenceNifti,distanceParam
         currentSphere=wmaPyTools.roiTools.createSphere(distanceParameter, subjectSpaceTractCoords[iCoords,:], referenceNifti)
         
         #get the sphere coords in image space
-        currentSphereImgCoords = np.array(np.where(currentSphere.get_data())).T
+        currentSphereImgCoords = np.array(np.where(currentSphere.get_fdata())).T
         
         #find the roi coords which correspond to voxels within the streamline mask
         validCoords=list(set(list(tuple([tuple(e) for e in currentSphereImgCoords]))) & set(imgSpaceTractVoxels))
@@ -802,7 +802,7 @@ def endpointDispersionAsymmetryMapping_Bootstrap(streamlines,referenceNifti,dist
         currentSphere=wmaPyTools.roiTools.createSphere(distanceParameter, subjectSpaceTractCoords[iCoords,:], referenceNifti)
         
         #get the sphere coords in image space
-        currentSphereImgCoords = np.array(np.where(currentSphere.get_data())).T
+        currentSphereImgCoords = np.array(np.where(currentSphere.get_fdata())).T
         
         #find the roi coords which correspond to voxels within the streamline mask
         validCoords=list(set(list(tuple([tuple(e) for e in currentSphereImgCoords]))) & set(imgSpaceTractVoxels))
@@ -999,7 +999,7 @@ def quantifyTractEndpoints(tractStreamlines,atlas,atlasLookupTable):
     
     #segment tractome into connectivity matrix from parcellation
     #   ENDPOINT GROUP MATTERS
-    M, grouping=utils.connectivity_matrix(tractStreamlines, atlas.affine, label_volume=renumberedAtlasNifti.get_data().astype(int),
+    M, grouping=utils.connectivity_matrix(tractStreamlines, atlas.affine, label_volume=renumberedAtlasNifti.get_fdata().astype(int),
                             symmetric=False,
                             return_mapping=True,
                             mapping_as_streamlines=False)
@@ -1038,7 +1038,7 @@ def inferReduceLUT_to_LabelNameCols(atlas,lookUpTable):
     #NOTE astype(int) is causing all sorts of problems, BE WARNED
     #first get the data out of the input atlas and *ensure* that it is Int
     #some atlases are being passed as float
-    inputAtlasDataINT=np.round(atlas.get_data()).astype(int)
+    inputAtlasDataINT=np.round(atlas.get_fdata()).astype(int)
       
     if isinstance(lookUpTable,str):
         if lookUpTable[-4:]=='.csv':
@@ -1114,7 +1114,7 @@ def coordinateLUTsAndAtlases(LUT1,LUT2,atlas1,atlas2):
     
     #what do we assume about negative numbers?
     #get the atlas data for atlas 2
-    atlas2Data=atlas2.get_data()
+    atlas2Data=atlas2.get_fdata()
     atlas2Data[atlas2Data>0]=atlas2Data[atlas2Data>0]+newLUT2start
     
     atlas2=nib.Nifti1Image(atlas2Data, atlas2.affine, atlas2.header)
@@ -1135,7 +1135,7 @@ def reduceLUTtoAvail(atlas,lookUpTable,removeAbsentLabels=True,reduceRenameColum
     #NOTE astype(int) is causing all sorts of problems, BE WARNED
     #first get the data out of the input atlas and *ensure* that it is Int
     #some atlases are being passed as float
-    inputAtlasDataINT=np.round(atlas.get_data()).astype(int)
+    inputAtlasDataINT=np.round(atlas.get_fdata()).astype(int)
       
     if isinstance(lookUpTable,str):
         if lookUpTable[-4:]=='.csv':
@@ -1553,7 +1553,7 @@ def reduceAtlasAndLookupTable(atlas,lookUpTable,removeAbsentLabels=True,reduceRe
     #NOTE astype(int) is causing all sorts of problems, BE WARNED
     #first get the data out of the input atlas and *ensure* that it is Int
     #some atlases are being passed as float
-    inputAtlasDataINT=np.round(atlas.get_data()).astype(int)
+    inputAtlasDataINT=np.round(atlas.get_fdata()).astype(int)
     
     [relabeledAtlasData, labelMappings]=reduce_labels(inputAtlasDataINT)
     #create new nifti object
@@ -1769,15 +1769,15 @@ def quantifyOverlapBetweenNiftis(ROI1,ROI2):
     #identify their types
     #kind of involves an assumption, in that we are inferring that a 2 unique 
     #value ROI is binary, and thus 0 and 1 or some equivalent
-    if len(np.unique(ROI1.get_data()))<=2:
+    if len(np.unique(ROI1.get_fdata()))<=2:
            ROI1type=bool
     else:
-        ROI1type=ROI1.get_data().dtype
+        ROI1type=ROI1.get_fdata().dtype
         
-    if len(np.unique(ROI2.get_data()))<=2:
+    if len(np.unique(ROI2.get_fdata()))<=2:
            ROI2type=bool
     else:
-        ROI2type=ROI2.get_data().dtype
+        ROI2type=ROI2.get_fdata().dtype
     
     #if either of these are bool, you've got to force them both to boolean
     #so that you can perform dice coefficient
@@ -1787,8 +1787,8 @@ def quantifyOverlapBetweenNiftis(ROI1,ROI2):
         #I'm assuming ravel ravels in a standard fashion and that this is safe.
         #also, we can use ravel given that these ROIs are presumably the same size
         #thanks to wmaPyTools.roiTools.alignNiftis
-        ROI1DataVec=np.ravel(ROI1.get_data().astype(bool))
-        ROI2DataVec=np.ravel(ROI2.get_data().astype(bool))
+        ROI1DataVec=np.ravel(ROI1.get_fdata().astype(bool))
+        ROI2DataVec=np.ravel(ROI2.get_fdata().astype(bool))
         #now compute the dice coefficient as the distance measure
         print('Computing dice coefficient')
         distanceMeasure=scipy.spatial.distance.dice(ROI1DataVec,ROI2DataVec)
@@ -1798,8 +1798,8 @@ def quantifyOverlapBetweenNiftis(ROI1,ROI2):
         #thanks to wmaPyTools.roiTools.alignNiftis
         #no need to modify datatype as before, though maybe an issue if different 
         #types, i.e. int vs float.
-        ROI1DataVec=np.ravel(ROI1.get_data())
-        ROI2DataVec=np.ravel(ROI2.get_data())
+        ROI1DataVec=np.ravel(ROI1.get_fdata())
+        ROI2DataVec=np.ravel(ROI2.get_fdata())
         #now compute the dice coefficient as the distance measure
         print('Computing cosine distance')
         distanceMeasure=scipy.spatial.distance.cosine(ROI1DataVec,ROI2DataVec)
@@ -1945,7 +1945,7 @@ def voxelwiseAtlasConnectivity(streamlines,atlasNifti,mask=None):
     
     #NOTE astype(int) is causing all sorts of problems, BE WARNED
     #using round as a workaround
-    [relabeledAtlasData, labelMappings]=utils.reduce_labels(np.round(atlasNifti.get_data()).astype(int))
+    [relabeledAtlasData, labelMappings]=utils.reduce_labels(np.round(atlasNifti.get_fdata()).astype(int))
     
    
     #if an input mask is actually provided
@@ -2157,7 +2157,7 @@ def iteratedTractSubComponentDensity(streamlines,atlas,lookupTable,refAnatT1,out
     
    
     #get the endpoint identities
-    M, grouping=utils.connectivity_matrix(streamlines, renumberedAtlasNifti.affine, label_volume=np.round(renumberedAtlasNifti.get_data()).astype(int),
+    M, grouping=utils.connectivity_matrix(streamlines, renumberedAtlasNifti.affine, label_volume=np.round(renumberedAtlasNifti.get_fdata()).astype(int),
                             return_mapping=True,
                             mapping_as_streamlines=False)
     #get the keys so that you can iterate through them later

--- a/wmaPyTools/roiTools.py
+++ b/wmaPyTools/roiTools.py
@@ -51,7 +51,7 @@ def makePlanarROI(reference, mmPlane, dimension):
     import numpy as np
     import dipy.tracking.utils as ut
     
-    fullMask = nib.nifti1.Nifti1Image(np.ones(reference.get_data().shape), reference.affine, reference.header)
+    fullMask = nib.nifti1.Nifti1Image(np.ones(reference.get_fdata().shape), reference.affine, reference.header)
     #pass full mask to subject space boundary function
     convertedBoundCoords=subjectSpaceMaskBoundaryCoords(fullMask)
     
@@ -120,7 +120,7 @@ def makePlanarROI(reference, mmPlane, dimension):
 #     import nibabel as nib
 #     outHeader = atlas.header.copy()
 #     #numpy and other stuff has been acting weird with ints lately
-#     atlasData = np.round(atlas.get_data()).astype(int)
+#     atlasData = np.round(atlas.get_fdata()).astype(int)
 #     outData = np.zeros((atlasData.shape)).astype(int)
 #     #check to make sure it is in the atlas
 #     #not entirely sure how boolean array behavior works here
@@ -284,7 +284,7 @@ def createSphere(r, p, reference, supress=True):
     if not supress:
         print('Creating '+ str(r) +' mm radius spherical roi at '+str(p))
     
-    fullMask = nib.nifti1.Nifti1Image(np.ones(reference.get_data().shape), reference.affine, reference.header)
+    fullMask = nib.nifti1.Nifti1Image(np.ones(reference.get_fdata().shape), reference.affine, reference.header)
     #obtain boundary coords in subject space in order set max min values for interactive visualization
     convertedBoundCoords=subjectSpaceMaskBoundaryCoords(fullMask)
     
@@ -369,14 +369,14 @@ def multiROIrequestToMask(atlas,roiNums,inflateIter=0):
     #force input roiNums to array, don't want to deal with lists and dicts
     roiNumsInArray=np.asarray(roiNums)
     
-    if  np.logical_not(np.all(np.isin(roiNumsInArray,np.unique(np.round(atlas.get_data()).astype(int))))):
+    if  np.logical_not(np.all(np.isin(roiNumsInArray,np.unique(np.round(atlas.get_fdata()).astype(int))))):
         import warnings
-        warnings.warn("WMA.multiROIrequestToMask WARNING: ROI label " + str(list(roiNumsInArray[np.logical_not(np.isin(roiNumsInArray,np.unique(np.round(atlas.get_data()).astype(int))))])) + " not found in input Nifti structure.")
+        warnings.warn("WMA.multiROIrequestToMask WARNING: ROI label " + str(list(roiNumsInArray[np.logical_not(np.isin(roiNumsInArray,np.unique(np.round(atlas.get_fdata()).astype(int))))])) + " not found in input Nifti structure.")
         
     #obtain coordiantes of all relevant label 
     #ATLASES ARE ACTING WEIRD THESE DAYS, gotta do round then int, not other way
     #if you don't do it this way, somehow you get a reduced number of labels
-    labelCoords=np.where(np.isin(np.round(atlas.get_data()).astype(int),roiNumsInArray))
+    labelCoords=np.where(np.isin(np.round(atlas.get_fdata()).astype(int),roiNumsInArray))
 
     #create blank data structure
     concatData=np.zeros(atlas.shape)
@@ -514,8 +514,8 @@ def sliceROIwithPlane(inputROINifti,inputPlanarROI,relativePosition):
     import numpy as np
     
     #get the data
-    inputROINiftiData=inputROINifti.get_data()
-    inputPlanarROIData=inputPlanarROI.get_data()
+    inputROINiftiData=inputROINifti.get_fdata()
+    inputPlanarROIData=inputPlanarROI.get_fdata()
     
     #boolean to check if intersection
     intersectBool=np.any(np.logical_and(inputROINiftiData!=0,inputPlanarROIData!=0))
@@ -525,14 +525,14 @@ def sliceROIwithPlane(inputROINifti,inputPlanarROI,relativePosition):
 
     #implement test to determine if input planar roi is indeed planar
     #get coordinates of mask voxels in image space
-    planeVoxCoords=np.where(inputPlanarROI.get_data())
+    planeVoxCoords=np.where(inputPlanarROI.get_fdata())
     #find the unique values of img space coordinates for each dimension
     uniqueCoordCounts=[len(np.unique(iCoords)) for iCoords in planeVoxCoords]
     #one of them should be singular in the case of a planar roi, throw an error if not
     if ~np.any(np.isin(uniqueCoordCounts,1)):
         raise ValueError('input cut ROI not planar (i.e. single voxel thick for True values)')
     
-    fullMask = nib.nifti1.Nifti1Image(np.ones(inputROINifti.get_data().shape), inputROINifti.affine, inputROINifti.header)
+    fullMask = nib.nifti1.Nifti1Image(np.ones(inputROINifti.get_fdata().shape), inputROINifti.affine, inputROINifti.header)
     #pass full mask to subject space boundary function
     fullVolumeBoundCoords=subjectSpaceMaskBoundaryCoords(fullMask)
     #get boundary mask coords for mask
@@ -655,7 +655,7 @@ def pointCoordsToNIFTI(coords,refNifti,radius=None):
     
     for iCoords in coords:
         currentSphere=createSphere(radius, iCoords, refNifti, supress=True)
-        blankNiftiData=np.add(blankNiftiData,currentSphere.get_data())
+        blankNiftiData=np.add(blankNiftiData,currentSphere.get_fdata())
         
     #create the output nifti
     outNifti=nib.nifti1.Nifti1Image(blankNiftiData, refNifti.affine, header=refNifti.header)
@@ -694,7 +694,7 @@ def alignROItoReference(inputROI,reference):
     densityKernel=np.asarray(reference.header.get_zooms())
     
     #get the coordinates themselves
-    roiCoords=seeds_from_mask(inputROI.get_data(), inputROI.affine, density=densityKernel)
+    roiCoords=seeds_from_mask(inputROI.get_fdata(), inputROI.affine, density=densityKernel)
     
     #use dipy functions to treat point cloud like one big streamline, and move it back to image space
     import dipy.tracking.utils as ut
@@ -747,8 +747,8 @@ def alignNiftis(nifti1,nifti2):
     #if they are the same resolution you don't do anything
     
     #roundabout hack: spoof a full mask to get the subject space boundary coords
-    fullMask1 = nib.nifti1.Nifti1Image(np.ones(nifti1.get_data().shape), nifti1.affine, nifti1.header)
-    fullMask2 = nib.nifti1.Nifti1Image(np.ones(nifti2.get_data().shape), nifti2.affine, nifti2.header)
+    fullMask1 = nib.nifti1.Nifti1Image(np.ones(nifti1.get_fdata().shape), nifti1.affine, nifti1.header)
+    fullMask2 = nib.nifti1.Nifti1Image(np.ones(nifti2.get_fdata().shape), nifti2.affine, nifti2.header)
     #pass full mask to subject space boundary function
     convertedBoundCoords1=subjectSpaceMaskBoundaryCoords(fullMask1)
     convertedBoundCoords2=subjectSpaceMaskBoundaryCoords(fullMask2)
@@ -814,7 +814,7 @@ def subjectSpaceMaskBoundaryCoords(maskNifti):
     import numpy as np
     
     #get the bounding box in image space
-    refDimBounds=np.asarray(mask.bounding_box(maskNifti.get_data()))
+    refDimBounds=np.asarray(mask.bounding_box(maskNifti.get_fdata()))
     
     #use itertools and cartesian product to generate vertex img space coordinates
     import itertools
@@ -863,8 +863,8 @@ def subjectSpaceMaskBoundaryCoords(maskNifti):
 
 #     #get 
 #     #nilearn doesn't handle NAN gracefully, so we have to be inelegant
-#     nifti1=nib.nifti1.Nifti1Image(np.nan_to_num(nifti1.get_data()), nifti1.affine, nifti1.header)
-#     nifti2=nib.nifti1.Nifti1Image(np.nan_to_num(nifti2.get_data()), nifti2.affine, nifti2.header)
+#     nifti1=nib.nifti1.Nifti1Image(np.nan_to_num(nifti1.get_fdata()), nifti1.affine, nifti1.header)
+#     nifti2=nib.nifti1.Nifti1Image(np.nan_to_num(nifti2.get_fdata()), nifti2.affine, nifti2.header)
     
 #     cropped1=crop_img(nifti1)
 #     cropped2=crop_img(nifti2)
@@ -1141,20 +1141,20 @@ def removeIslandsFromAtlas(atlasNifti):
         atlas=atlasNifti
 
 
-    # atlasData=np.round(atlas.get_data()).astype(int)
+    # atlasData=np.round(atlas.get_fdata()).astype(int)
     # #COSIDER REPLACING ALL OR MOST OF THIS WITH
     #Doesn't seem to work?
     # relabelConnectedData=scipy.ndimage.measurements.label(atlasData.astype(bool))
 
     #count the label instances, and make an inference as to the background value
     #it's almost certianly the most common value, eg. 0
-    (labels,counts)=np.unique(atlas.get_data(), return_counts=True)
+    (labels,counts)=np.unique(atlas.get_fdata(), return_counts=True)
     detectBackground=int(labels[np.where(np.max(counts)==counts)[0]])
     
     #get the list of labels without the background
     atlasLabels=labels.astype(int)[labels.astype(int)!=detectBackground]
     
-    atlasData=atlas.get_data()
+    atlasData=atlas.get_fdata()
     removalReport=pd.DataFrame(columns=['label','max_erosion','islands_removed'])
     #remove the background values
     for iLabels in atlasLabels:
@@ -1166,7 +1166,7 @@ def removeIslandsFromAtlas(atlasNifti):
         #the default max iterations, will be reduced in cases where implementation
         #results in complete loss
         forcedMaxIterations=3
-        currentErosion=atlas.get_data()==iLabels
+        currentErosion=atlas.get_fdata()==iLabels
         #I guess we can use this to set something like minimum island size?
         #a 3x3 block (last before singleton point) would have 27 voxels in it
         #using strcit less than allows for escape in cases where forcedMaxIterations
@@ -1178,25 +1178,25 @@ def removeIslandsFromAtlas(atlasNifti):
             if np.sum(currentErosion) ==0:
                 forcedMaxIterations=forcedMaxIterations-1
                 erosionIterations=0
-                currentErosion=atlas.get_data()==iLabels
+                currentErosion=atlas.get_fdata()==iLabels
         #print how much was eroded
-        print(str(np.abs(np.sum(currentErosion) - (np.sum(atlas.get_data()==iLabels))))+ ' of ' + str(np.sum(atlas.get_data()==iLabels)) + ' voxels eroded label ' + str(iLabels) )
+        print(str(np.abs(np.sum(currentErosion) - (np.sum(atlas.get_fdata()==iLabels))))+ ' of ' + str(np.sum(atlas.get_fdata()==iLabels)) + ' voxels eroded label ' + str(iLabels) )
         #add that value to the report list for this label
-        reportRow.append(np.abs(np.sum(currentErosion) - (np.sum(atlas.get_data()==iLabels))))
+        reportRow.append(np.abs(np.sum(currentErosion) - (np.sum(atlas.get_fdata()==iLabels))))
         #perform the propigation function, wherein the eroded label is inflated back
-        #islandRemoved=scipy.ndimage.binary_propagation(currentErosion, structure=np.ones([3,3,3]).astype(int), mask=atlas.get_data()==iLabels)
-        islandRemoved=scipy.ndimage.binary_propagation(currentErosion, mask=atlas.get_data()==iLabels)
+        #islandRemoved=scipy.ndimage.binary_propagation(currentErosion, structure=np.ones([3,3,3]).astype(int), mask=atlas.get_fdata()==iLabels)
+        islandRemoved=scipy.ndimage.binary_propagation(currentErosion, mask=atlas.get_fdata()==iLabels)
         #print the resulting difference between the intitial label and this eroded+inflated one
-        print(str(np.abs(np.sum(islandRemoved) - (np.sum(atlas.get_data()==iLabels))))+ ' of ' + str(np.sum(atlas.get_data()==iLabels)) + ' voxels removed for label ' + str(iLabels) )
+        print(str(np.abs(np.sum(islandRemoved) - (np.sum(atlas.get_fdata()==iLabels))))+ ' of ' + str(np.sum(atlas.get_fdata()==iLabels)) + ' voxels removed for label ' + str(iLabels) )
         #add that value to the report list for this label
-        reportRow.append(np.abs(np.sum(islandRemoved) - (np.sum(atlas.get_data()==iLabels))))
+        reportRow.append(np.abs(np.sum(islandRemoved) - (np.sum(atlas.get_fdata()==iLabels))))
         #add the row to the output report
         removalReport.loc[len(removalReport)]=reportRow
 
         #now actually modify the data
         #what you want are the areas that are true in the origional atlas but false in the eroded+inflated version
         #set those to background
-        atlasData[np.logical_and(atlas.get_data()==iLabels,np.logical_not(islandRemoved))]=detectBackground
+        atlasData[np.logical_and(atlas.get_fdata()==iLabels,np.logical_not(islandRemoved))]=detectBackground
     
         #make a nifti of it
         atlasNiftiOut=nib.Nifti1Image(atlasData, atlas.affine, atlas.header)
@@ -1433,7 +1433,7 @@ def inflateAtlasIntoWMandBG(atlasNifti,iterations,inferWM=False):
         
     #count the label instances, and make an inference as to the background value
     #it's almost certianly the most common value, eg. 0
-    (labels,counts)=np.unique(atlas.get_data(), return_counts=True)
+    (labels,counts)=np.unique(atlas.get_fdata(), return_counts=True)
     detectBackground=int(labels[np.where(np.max(counts)==counts)[0]])
     
     #now comes a tougher part, how do we detect WM labels, if any (because they might not be there)
@@ -1490,7 +1490,7 @@ def inflateAtlasIntoWMandBG(atlasNifti,iterations,inferWM=False):
     #so long as nothing is on the edge this will probably work, due to coord weirdness
     #This was forshadowing, code updated on 1/12/22 to take care of this
     #get the image data
-    noIslandAtlasData=noIslandAtlas.get_data()
+    noIslandAtlasData=noIslandAtlas.get_fdata()
     noIslandAtlasData=np.round(noIslandAtlasData).astype(int)
     
     atlasBounds=subjectSpaceMaskBoundaryCoords(atlas)  
@@ -1653,7 +1653,7 @@ def extendROIinDirection(roiNifti,direction,iterations):
         direction=list(direction)
         
     #go ahead and do the inflation
-    concatData=ndimage.binary_dilation(roiNifti.get_data(), iterations=iterations)
+    concatData=ndimage.binary_dilation(roiNifti.get_fdata(), iterations=iterations)
     
     #convert that data array to a nifti
     extendedROI=nib.Nifti1Image(concatData, roiNifti.affine, roiNifti.header)
@@ -1690,7 +1690,7 @@ def boundaryROIPlanesFromMask(inputMask):
         inputMask=nib.load(inputMask)
         
     #create a binarized copy of the mask
-    binarizedMask=nib.Nifti1Image(inputMask.get_data()>0, inputMask.affine, inputMask.header)
+    binarizedMask=nib.Nifti1Image(inputMask.get_fdata()>0, inputMask.affine, inputMask.header)
     
     #initialize the output directory
     borderDict={}
@@ -1746,7 +1746,7 @@ def findROISintersection(ROIs,inflateiter=0):
     intersectionNifti=masking.intersect_masks(ROIs, threshold=1)
     
     #if it's empty throw a warning
-    if not np.any(intersectionNifti.get_data()):
+    if not np.any(intersectionNifti.get_fdata()):
         import warnings
         warnings.warn("Empty mask for intersection returned; likely no mutual intersection between input " + str(len(ROIs)) + "ROIs")
                       
@@ -1755,7 +1755,7 @@ def findROISintersection(ROIs,inflateiter=0):
 def changeLabelValue(inputParc,targetLabelNum,newLabelNum):
     import numpy as np
     import nibabel as nib
-    parcData=inputParc.get_data().astype(int)
+    parcData=inputParc.get_fdata().astype(int)
     locations=np.where(parcData==targetLabelNum)
     #this takes a bewilderingly long time
     #I must be using it wrong
@@ -1868,8 +1868,8 @@ def mergeVolParcellations(parc1, parc2, parc1LUT, parc2LUT,parc1_override_labels
     
     #detect conflicts
     #extract data
-    parc1Data=parc1.get_data().astype(int)
-    parc2Data=parc2.get_data().astype(int)
+    parc1Data=parc1.get_fdata().astype(int)
+    parc2Data=parc2.get_fdata().astype(int)
     
     #find out which one is bigger, use datasize as the guide.  Datatype shouldn't
     #be a confound at this point because we converted to int
@@ -1882,12 +1882,12 @@ def mergeVolParcellations(parc1, parc2, parc1LUT, parc2LUT,parc1_override_labels
         print ('parc1 size of ' + str(np.round(parc1DataSize/(1024**2))) + ' MB greater than parc2 size of ' + str(np.round(parc2DataSize/(1024**2))) + ' MB')
         print ('resampling to parc1' )
         parc2=resample_img(parc2,target_affine=parc1.affine,target_shape=(parc1.shape),interpolation='nearest')
-        parc2Data=parc2.get_data().astype(int)
+        parc2Data=parc2.get_fdata().astype(int)
     elif parc2DataSize>parc1DataSize:
         print ('parc2 size of ' + str(np.round(parc2DataSize/(1024**2))) + ' MB greater than parc1 size of ' + str(np.round(parc1DataSize/(1024**2))) + ' MB')
         print ('resampling to parc2' )
         parc1=resample_img(parc1,target_affine=parc2.affine,target_shape=(parc2.shape),interpolation='nearest')
-        parc1Data=parc1.get_data().astype(int)
+        parc1Data=parc1.get_fdata().astype(int)
     elif parc1Data.shape==parc2Data.shape:
         print ('Input parcellations same data shape, proceeding without modification')
     else:

--- a/wmaPyTools/segmentationTools.py
+++ b/wmaPyTools/segmentationTools.py
@@ -404,7 +404,7 @@ def applyNiftiCriteriaToTract_DIPY(streamlines, maskNifti, includeBool, operatio
     #tractmask, but nonetheless within the tolerance.
     tractMask=scipy.ndimage.binary_dilation(tractMask.astype(bool), iterations=1)
     #convert int-based voxel-wise count data to int because apparently that's the only way you can save with nibabel
-    tractMask=nib.Nifti1Image(np.greater(tractMask,0).astype(int), affine=maskNifti.affine)
+    tractMask=nib.Nifti1Image(np.greater(tractMask,0).astype('int32'), affine=maskNifti.affine)
 
     #take the intersection of the two, the tract mask and the ROI mask nifti.
     #ideally we are reducing the number of points that each streamline node needs to be compared to
@@ -827,7 +827,7 @@ def applyNiftiCriteriaToTract_DIPY_Test(streamlines, maskNifti, includeBool, ope
     #tractmask, but nonetheless within the tolerance.
     tractMask=scipy.ndimage.binary_dilation(tractMask.astype(bool), iterations=1)
     #convert int-based voxel-wise count data to int because apparently that's the only way you can save with nibabel
-    tractMask=nib.Nifti1Image(np.greater(tractMask,0).astype(int), affine=maskNifti.affine)
+    tractMask=nib.Nifti1Image(np.greater(tractMask,0).astype('int32'), affine=maskNifti.affine)
 
     #take the intersection of the two, the tract mask and the ROI mask nifti.
     #ideally we are reducing the number of points that each streamline node needs to be compared to

--- a/wmaPyTools/segmentationTools.py
+++ b/wmaPyTools/segmentationTools.py
@@ -80,7 +80,7 @@ def speedSortSegCriteria(criteriaROIs,inclusionCriteria,operations):
     volumesToCheck=np.zeros(len(criteriaROIs))
     for iROIs in range(len(criteriaROIs)):
         #compute the volume that needs to be checked
-        volumesToCheck[iROIs]=np.sum(criteriaROIs[iROIs].get_data())
+        volumesToCheck[iROIs]=np.sum(criteriaROIs[iROIs].get_fdata())
 
     print("volumes of input ROIs to check " + str(volumesToCheck))
     #find the criteria that only involve endpoints (you don't have to check all the nodes
@@ -118,7 +118,7 @@ def speedSortSegCriteria(criteriaROIs,inclusionCriteria,operations):
         sortedInclusionCriteria.append(inclusionCriteria[outOrder[iOutputs]])
         sortedOperations.append(operations[outOrder[iOutputs]])
         
-        volumesToCheckOut[iOutputs]=np.sum(sortedCriteriaROIs[iOutputs].get_data()).astype(int)
+        volumesToCheckOut[iOutputs]=np.sum(sortedCriteriaROIs[iOutputs].get_fdata()).astype(int)
         #if it is an exclusion, get the number of streamlines that are left out
     print("volumes of output ROIs to check " + str(volumesToCheckOut))
     
@@ -331,7 +331,7 @@ def segmentTractMultiROI_fast(streamlines, roisVec, includeVec, operationsVec):
     #iterate across segmentation operations
     for iOperations in range(len(roisVec)):
         #perform this segmentation operation
-        curBoolVec=near_roi_fast(streamlines[remainingStreamIndexes], roisVec[iOperations].affine, roisVec[iOperations].get_data(),mode=operationsVec[iOperations])
+        curBoolVec=near_roi_fast(streamlines[remainingStreamIndexes], roisVec[iOperations].affine, roisVec[iOperations].get_fdata(),mode=operationsVec[iOperations])
         #if the inclusion operation requires it, negate the output
         if not includeVec[iOperations]:
             curBoolVec=np.logical_not(curBoolVec)
@@ -391,7 +391,7 @@ def applyNiftiCriteriaToTract_DIPY(streamlines, maskNifti, includeBool, operatio
         raise Exception("applyNiftiCriteriaToTract Error: input maskNifti not a nifti.")
     
     #the conversion to int may cause problems if the input isn't convertable to int.  Then again, the point of this is to raise an error, so...
-    elif np.logical_not(np.all(np.unique(maskNifti.get_data()).astype(int)==[0, 1])): 
+    elif np.logical_not(np.all(np.unique(maskNifti.get_fdata()).astype(int)==[0, 1])): 
         raise Exception("applyNiftiCriteriaToTract Error: input maskNifti not convertable to 0,1 int mask.  Likely not a mask.")
         
     if np.logical_not(isinstance(includeBool, bool )):
@@ -434,7 +434,7 @@ def applyNiftiCriteriaToTract_DIPY(streamlines, maskNifti, includeBool, operatio
     #second track mask application doesn't seem to do anything    
     
     #use dipy's near roi function to generate bool
-    criteriaStreamsBool=near_roi(boundedStreamSubset, tractMaskROIIntersection.affine, tractMaskROIIntersection.get_data().astype(bool), mode=operationSpec)
+    criteriaStreamsBool=near_roi(boundedStreamSubset, tractMaskROIIntersection.affine, tractMaskROIIntersection.get_fdata().astype(bool), mode=operationSpec)
        
     #find the indexes of the original streamlines that the survivors correspond to
     boundedStreamsIndexes=np.where(boundedStreamsBool)[0]
@@ -810,8 +810,8 @@ def applyNiftiCriteriaToTract_DIPY_Test(streamlines, maskNifti, includeBool, ope
         raise Exception("applyNiftiCriteriaToTract Error: input maskNifti not a nifti.")
     
     #the conversion to int may cause problems if the input isn't convertable to int.  Then again, the point of this is to raise an error, so...
-    elif np.logical_not(np.all(np.unique(maskNifti.get_data()).astype(int)==[0, 1])): 
-        if np.all(np.unique(maskNifti.get_data()).astype(int)[0]==0):
+    elif np.logical_not(np.all(np.unique(maskNifti.get_fdata()).astype(int)==[0, 1])): 
+        if np.all(np.unique(maskNifti.get_fdata()).astype(int)[0]==0):
             import warnings
             warnings.warn("input mask nifti empty.")
         else:
@@ -861,7 +861,7 @@ def applyNiftiCriteriaToTract_DIPY_Test(streamlines, maskNifti, includeBool, ope
     #use dipy's near roi function to generate bool
     #start timing
     t1_start=time.process_time()
-    criteriaStreamsBool=near_roi(outStreams, tractMaskROIIntersection.affine, tractMaskROIIntersection.get_data().astype(bool), mode=operationSpec)
+    criteriaStreamsBool=near_roi(outStreams, tractMaskROIIntersection.affine, tractMaskROIIntersection.get_fdata().astype(bool), mode=operationSpec)
     #stop timing
     t1_stop=time.process_time()
     # get the elapsed time
@@ -1031,7 +1031,7 @@ def applyEndpointCriteria(streamlines,planarROI,requirement,whichEndpoints):
     # import nibabel as nib
     # import wmaPyTools.roiTools 
     
-    fullMask = nib.nifti1.Nifti1Image(np.ones(planarROI.get_data().shape), planarROI.affine, planarROI.header)
+    fullMask = nib.nifti1.Nifti1Image(np.ones(planarROI.get_fdata().shape), planarROI.affine, planarROI.header)
     #obtain boundary coords in subject space in order set max min values for interactive visualization
     convertedBoundCoords=wmaPyTools.roiTools.subjectSpaceMaskBoundaryCoords(fullMask)
 
@@ -1039,7 +1039,7 @@ def applyEndpointCriteria(streamlines,planarROI,requirement,whichEndpoints):
     #get coordinates of mask voxels in image space
     
     from dipy.tracking.utils import apply_affine
-    planeSubjCoords=apply_affine(planarROI.affine, np.array(np.where(planarROI.get_data())).T)
+    planeSubjCoords=apply_affine(planarROI.affine, np.array(np.where(planarROI.get_fdata())).T)
     #find the unique values of img space coordinates for each dimension
     uniqueCoordCounts=[len(np.unique(planeSubjCoords[:,iCoords])) for iCoords in list(range(planeSubjCoords.shape[1]))]
     #one of them should be singular in the case of a planar roi, throw an error if not
@@ -1122,7 +1122,7 @@ def applyMidpointCriteria(streamlines,planarROI,requirement):
     # import nibabel as nib
     # import wmaPyTools.roiTools  
     
-    fullMask = nib.nifti1.Nifti1Image(np.ones(planarROI.get_data().shape), planarROI.affine, planarROI.header)
+    fullMask = nib.nifti1.Nifti1Image(np.ones(planarROI.get_fdata().shape), planarROI.affine, planarROI.header)
     #obtain boundary coords in subject space in order set max min values for interactive visualization
     convertedBoundCoords=wmaPyTools.roiTools.subjectSpaceMaskBoundaryCoords(fullMask)
 
@@ -1130,7 +1130,7 @@ def applyMidpointCriteria(streamlines,planarROI,requirement):
     #get coordinates of mask voxels in image space
     
     from dipy.tracking.utils import apply_affine
-    planeSubjCoords=apply_affine(planarROI.affine, np.array(np.where(planarROI.get_data())).T)
+    planeSubjCoords=apply_affine(planarROI.affine, np.array(np.where(planarROI.get_fdata())).T)
     #find the unique values of img space coordinates for each dimension
     uniqueCoordCounts=[len(np.unique(planeSubjCoords[:,iCoords])) for iCoords in list(range(planeSubjCoords.shape[1]))]
     #one of them should be singular in the case of a planar roi, throw an error if not
@@ -1318,14 +1318,14 @@ def applyNiftiCriteriaToTract_DIPY_Cython(streamlines, maskNifti, includeBool, o
         raise Exception("applyNiftiCriteriaToTract Error: input maskNifti not a nifti.")
     
     #the conversion to int may cause problems if the input isn't convertable to int.  Then again, the point of this is to raise an error, so...
-    elif np.logical_not(np.all(np.unique(maskNifti.get_data()).astype(int)==[0, 1])): 
+    elif np.logical_not(np.all(np.unique(maskNifti.get_fdata()).astype(int)==[0, 1])): 
         raise Exception("applyNiftiCriteriaToTract Error: input maskNifti not convertable to 0,1 int mask.  Likely not a mask.")
         
     if np.logical_not(isinstance(includeBool, bool )):
         raise Exception("applyNiftiCriteriaToTract Error: input includeBool not a bool.  See input description for usage")
         
     lin_T, offset =ut._mapping_to_voxel(maskNifti.affine)
-    criteriaStreamsBool=_streamlines_in_mask( list(streamlines), maskNifti.get_data().astype(np.uint8), lin_T, offset)
+    criteriaStreamsBool=_streamlines_in_mask( list(streamlines), maskNifti.get_fdata().astype(np.uint8), lin_T, offset)
     
     if includeBool==True:
         #initalize an out bool vec
@@ -1441,7 +1441,7 @@ def tractProbabilityMap2SegCriteria(singleTractProbMap):
     #thresholdProportion=.7
     #next we find where this is in the unique values of the datablock
     #and set it as our threshold value
-    #threshVal=np.unique(singleTractProbMap.get_data())[np.floor(len(np.unique(singleTractProbMap.get_data()))*thresholdProportion).astype(int)]
+    #threshVal=np.unique(singleTractProbMap.get_fdata())[np.floor(len(np.unique(singleTractProbMap.get_fdata()))*thresholdProportion).astype(int)]
     
     #lets get to making the planar coordinates
     planarInclusionROIs=[]
@@ -1466,8 +1466,8 @@ def densityMaskToSegCriteria(densityMask):
     #MAJOR INSIGHT:  it is never the case that endpoints can be in the "core" of a
     #tract.  Ergo, you can erode the mask a bit and use it as an endpoint exclusion criterion, 
     # but also as a traversal criterion
-    coreMask=scipy.ndimage.binary_erosion(densityMask.get_data(), iterations=2)
-    inflatedMask=scipy.ndimage.binary_dilation(densityMask.get_data(), iterations=1)
+    coreMask=scipy.ndimage.binary_erosion(densityMask.get_fdata(), iterations=2)
+    inflatedMask=scipy.ndimage.binary_dilation(densityMask.get_fdata(), iterations=1)
     endpointsMask=copy.deepcopy(inflatedMask)
     endpointsMask[coreMask]=False
     

--- a/wmaPyTools/streamlineTools.py
+++ b/wmaPyTools/streamlineTools.py
@@ -1968,8 +1968,8 @@ def trackStreamsInMask(targetMask,seed_density,wmMask,dwi,bvecs,bvals):
 
     gtab = gradient_table(bvals, bvecs)
 
-    response, ratio = auto_response_ssst(gtab, dwi.get_data(), roi_radii=10, fa_thr=0.7)
-    #response, ratio = auto_response(gtab, dwi.get_data(), roi_radii=10, fa_thr=0.7)
+    response, ratio = auto_response_ssst(gtab, dwi.get_fdata(), roi_radii=10, fa_thr=0.7)
+    #response, ratio = auto_response(gtab, dwi.get_fdata(), roi_radii=10, fa_thr=0.7)
     
     csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=6)
     
@@ -1978,7 +1978,7 @@ def trackStreamsInMask(targetMask,seed_density,wmMask,dwi,bvecs,bvals):
     #no white matter mask for now?
     wmOnDwi=image.resample_to_img(wmMask,dwi,interpolation='nearest')
     
-    csd_fit = csd_model.fit(dwi.get_data(), mask=wmOnDwi.get_data())
+    csd_fit = csd_model.fit(dwi.get_fdata(), mask=wmOnDwi.get_fdata())
 
     # prob_dg = ProbabilisticDirectionGetter.from_shcoeff(csd_fit.shm_coeff,
     #                                                 max_angle=30.,
@@ -1986,7 +1986,7 @@ def trackStreamsInMask(targetMask,seed_density,wmMask,dwi,bvecs,bvals):
     
     
     csa_model = CsaOdfModel(gtab, sh_order=6)
-    gfa = csa_model.fit(dwi.get_data(), mask=wmOnDwi.get_data()).gfa
+    gfa = csa_model.fit(dwi.get_fdata(), mask=wmOnDwi.get_fdata()).gfa
     stopping_thr= 0.2
     stopping_criterion = ThresholdStoppingCriterion(gfa, stopping_thr)
     
@@ -1996,7 +1996,7 @@ def trackStreamsInMask(targetMask,seed_density,wmMask,dwi,bvecs,bvals):
                                                     sphere=default_sphere)   
 
    
-    seeds = utils.seeds_from_mask(targetMask.get_data(), targetMask.affine, density=seed_density)
+    seeds = utils.seeds_from_mask(targetMask.get_fdata(), targetMask.affine, density=seed_density)
     step_size= dist_to_corner(targetMask.affine)
     
     
@@ -2182,7 +2182,7 @@ def manualSelectStreams_byEndpoint(streamlines,parc,lookupTable,targetLabels):
     #begin by reducing the input atlas
     [renumberedAtlasNifti,reducedLookupTable]=wmaPyTools.analysisTools.reduceAtlasAndLookupTable(parc,lookupTable,removeAbsentLabels=True)
     #then do the endpoint connectivity matrix
-    M, grouping=utils.connectivity_matrix(streamlines, np.round(renumberedAtlasNifti.affine,2), label_volume=renumberedAtlasNifti.get_data().astype(int),
+    M, grouping=utils.connectivity_matrix(streamlines, np.round(renumberedAtlasNifti.affine,2), label_volume=renumberedAtlasNifti.get_fdata().astype(int),
                             symmetric=False,
                             return_mapping=True,
                             mapping_as_streamlines=False)

--- a/wmaPyTools/visTools.py
+++ b/wmaPyTools/visTools.py
@@ -52,10 +52,10 @@ Created on Sun Dec  5 16:03:14 2021
 #             fig,ax = plt.subplots()
 #             ax.axis('off')
 #             #kind of overwhelming to do this in one line
-#             refData=np.rot90(np.reshape(croppedReference.get_data()[currentSlice.get_data().astype(bool)],broadcastShape),3)
+#             refData=np.rot90(np.reshape(croppedReference.get_fdata()[currentSlice.get_fdata().astype(bool)],broadcastShape),3)
 #             plt.imshow(refData, cmap='gray', interpolation='nearest')
 #             #kind of overwhelming to do this in one line
-#             densityData=np.rot90(np.reshape(densityNifti.get_data()[currentSlice.get_data().astype(bool)],broadcastShape),3)
+#             densityData=np.rot90(np.reshape(densityNifti.get_fdata()[currentSlice.get_fdata().astype(bool)],broadcastShape),3)
 #             plt.imshow(np.ma.masked_where(densityData<1,densityData), cmap='viridis', alpha=.5, interpolation='nearest')
 #             figName='dim_' + str(iDims) +'_'+  str(iSlices).zfill(3)
 #             plt.savefig(figName,bbox_inches='tight')
@@ -85,7 +85,7 @@ def plotMultiGifsFrom4DNifti(fourDNifti,referenceAnatomy,saveDir):
         if not os.path.exists(outPath):
             os.makedirs(outPath)
         #just try it, maybe it will work
-        densityNifti=nib.nifti1.Nifti1Image(fourDNifti.get_data()[:,:,:,iSlices],referenceAnatomy.affine,referenceAnatomy.header)
+        densityNifti=nib.nifti1.Nifti1Image(fourDNifti.get_fdata()[:,:,:,iSlices],referenceAnatomy.affine,referenceAnatomy.header)
         crossSectionGIFsFromNifti(densityNifti,referenceAnatomy,outPath) 
         
 def dispersionReport(outDict,streamlines,saveDir,refAnatT1,distanceParameter=3):
@@ -165,7 +165,7 @@ def dispersionReport(outDict,streamlines,saveDir,refAnatT1,distanceParameter=3):
         if not os.path.exists(outPath):
             os.makedirs(outPath)
         
-        currentData=outDict[iOutFiles].get_data()
+        currentData=outDict[iOutFiles].get_fdata()
         smallestNotZero=np.unique(currentData)[1]
         crossSectionGIFsFromNifti(outDict[iOutFiles],refAnatT1,outPath, blendOption=False)
         #lets mask out the background
@@ -278,18 +278,18 @@ def generateAnatOverlayXSections(overlayNifti,refAnatT1,saveDir):
             fig,ax = plt.subplots()
             ax.axis('off')
             #kind of overwhelming to do this in one line
-            refData=np.rot90(np.reshape(refAnatT1.get_data()[currentRefSlice.get_data().astype(bool)],broadcastShape),1)
+            refData=np.rot90(np.reshape(refAnatT1.get_fdata()[currentRefSlice.get_fdata().astype(bool)],broadcastShape),1)
             plt.imshow(refData, cmap='gray', interpolation='antialiased')
             #kind of overwhelming to do this in one line
-            overlayData=np.rot90(np.reshape(overlayNifti.get_data()[currentOverlaySlice.get_data().astype(bool)],broadcastShape),1)
+            overlayData=np.rot90(np.reshape(overlayNifti.get_fdata()[currentOverlaySlice.get_fdata().astype(bool)],broadcastShape),1)
             #lets mask out the background
             [unique, counts] = np.unique(overlayData, return_counts=True)
             backgroundVal=unique[np.where(np.max(counts)==counts)[0]]
             
-            plt.imshow(np.ma.masked_where(overlayData==backgroundVal,overlayData), cmap='jet', alpha=.75, interpolation='antialiased',vmin=0,vmax=np.nanmax(overlayNifti.get_data()))
+            plt.imshow(np.ma.masked_where(overlayData==backgroundVal,overlayData), cmap='jet', alpha=.75, interpolation='antialiased',vmin=0,vmax=np.nanmax(overlayNifti.get_fdata()))
             curFig=plt.gcf()
             cbaxes = inset_axes(curFig.gca(), width="5%", height="80%", loc=5) 
-            plt.colorbar(cax=cbaxes, ticks=[0.,np.nanmax(overlayNifti.get_data())], orientation='vertical')
+            plt.colorbar(cax=cbaxes, ticks=[0.,np.nanmax(overlayNifti.get_fdata())], orientation='vertical')
             
             #put some text about the current dimension and slice
             yLims=curFig.gca().get_ylim()
@@ -329,7 +329,7 @@ def multiTileOverlay_wrap(overlayNifti,refAnatT1,saveDir,figName,noEmpties=True,
     
     generateAnatOverlayXSections(overlayNifti,refAnatT1,saveDir)
     
-    imgSpaceMins, imgSpaceMaxs=bounding_box(overlayNifti.get_data())
+    imgSpaceMins, imgSpaceMaxs=bounding_box(overlayNifti.get_fdata())
     
     overlayShape=overlayNifti.shape
     refT1Shape=refAnatT1.shape
@@ -468,8 +468,8 @@ def multiTileDensity(streamlines,refAnatT1,saveDir,tractName,densityThreshold=0,
     # #change datatype so that nilearn doesn't mess up
     # #it doesn't like bool so we have to do something about that
     # #somehow the data can be set to nifti, but can't be extracted as nifti, so...
-    # overlayNifti=nib.nifti1.Nifti1Image(overlayNifti.get_data(),overlayNifti.affine,overlayNifti.header)
-    # overlayNifti.set_data_dtype(overlayNifti.get_data().dtype)
+    # overlayNifti=nib.nifti1.Nifti1Image(overlayNifti.get_fdata(),overlayNifti.affine,overlayNifti.header)
+    # overlayNifti.set_data_dtype(overlayNifti.get_fdata().dtype)
     
     #resample to the best resolution
     #but also assuming that the refernce anatomy is ultimately the shape that we want
@@ -532,15 +532,15 @@ def multiTileDensity(streamlines,refAnatT1,saveDir,tractName,densityThreshold=0,
             fig,ax = plt.subplots()
             ax.axis('off')
             #kind of overwhelming to do this in one line
-            refData=np.rot90(np.reshape(refAnatT1.get_data()[currentRefSlice.get_data().astype(bool)],broadcastShape),1)
+            refData=np.rot90(np.reshape(refAnatT1.get_fdata()[currentRefSlice.get_fdata().astype(bool)],broadcastShape),1)
             plt.imshow(refData, cmap='gray', interpolation='gaussian')
             #kind of overwhelming to do this in one line
-            overlayData=np.rot90(np.reshape(overlayNifti.get_data()[currentOverlaySlice.get_data().astype(bool)],broadcastShape),1)
+            overlayData=np.rot90(np.reshape(overlayNifti.get_fdata()[currentOverlaySlice.get_fdata().astype(bool)],broadcastShape),1)
             #lets mask out the background
             [unique, counts] = np.unique(overlayData, return_counts=True)
             backgroundVal=unique[np.where(np.max(counts)==counts)[0]]
             
-            plt.imshow(np.ma.masked_where(overlayData==backgroundVal,overlayData), cmap='jet', alpha=.75, interpolation='kaiser',vmin=0,vmax=np.nanmax(overlayNifti.get_data()))
+            plt.imshow(np.ma.masked_where(overlayData==backgroundVal,overlayData), cmap='jet', alpha=.75, interpolation='kaiser',vmin=0,vmax=np.nanmax(overlayNifti.get_fdata()))
             curFig=plt.gcf()
             yLims=sorted(curFig.gca().get_ylim())
             xLims=sorted(curFig.gca().get_xlim())
@@ -553,7 +553,7 @@ def multiTileDensity(streamlines,refAnatT1,saveDir,tractName,densityThreshold=0,
             
             #be careful here, modifying the cbaxes  modifies the current figure
             cbaxes = inset_axes(curFig.gca(), width="5%", height="80%", loc=5) 
-            plt.colorbar(cax=cbaxes, ticks=[0.,np.nanmax(overlayNifti.get_data())], orientation='vertical')
+            plt.colorbar(cax=cbaxes, ticks=[0.,np.nanmax(overlayNifti.get_fdata())], orientation='vertical')
             
             
             #put some text about the current dimension and slice
@@ -675,7 +675,7 @@ def crossSectionGIFsFromNifti(overlayNifti,refAnatT1,saveDir, blendOption=False)
     #reference, we can crop the overlay safely and work adaptively.  Why would
     #you even have overlay **outside** of the refernce
     #nilearn doesn't handle NAN gracefully, so we have to be inelegant
-    #overlayNifti=nib.nifti1.Nifti1Image(np.nan_to_num(overlayNifti.get_data()), overlayNifti.affine, overlayNifti.header)
+    #overlayNifti=nib.nifti1.Nifti1Image(np.nan_to_num(overlayNifti.get_fdata()), overlayNifti.affine, overlayNifti.header)
     #croppedOverlayNifti=crop_img(overlayNifti)
     
     #RAS reoreintation
@@ -700,8 +700,8 @@ def crossSectionGIFsFromNifti(overlayNifti,refAnatT1,saveDir, blendOption=False)
     #change datatype so that nilearn doesn't mess up
     #it doesn't like bool so we have to do something about that
     #somehow the data can be set to nifti, but can't be extracted as nifti, so...
-    overlayNifti=nib.nifti1.Nifti1Image(overlayNifti.get_data(),overlayNifti.affine,overlayNifti.header)
-    overlayNifti.set_data_dtype(overlayNifti.get_data().dtype)
+    overlayNifti=nib.nifti1.Nifti1Image(overlayNifti.get_fdata(),overlayNifti.affine,overlayNifti.header)
+    overlayNifti.set_data_dtype(overlayNifti.get_fdata().dtype)
     
     #resample to the best resolution
     #but also assuming that the refernce anatomy is ultimately the shape that we want
@@ -752,18 +752,18 @@ def crossSectionGIFsFromNifti(overlayNifti,refAnatT1,saveDir, blendOption=False)
             fig,ax = plt.subplots()
             ax.axis('off')
             #kind of overwhelming to do this in one line
-            refData=np.rot90(np.reshape(refAnatT1.get_data()[currentRefSlice.get_data().astype(bool)],broadcastShape),1)
+            refData=np.rot90(np.reshape(refAnatT1.get_fdata()[currentRefSlice.get_fdata().astype(bool)],broadcastShape),1)
             plt.imshow(refData, cmap='gray', interpolation='gaussian')
             #kind of overwhelming to do this in one line
-            overlayData=np.rot90(np.reshape(overlayNifti.get_data()[currentOverlaySlice.get_data().astype(bool)],broadcastShape),1)
+            overlayData=np.rot90(np.reshape(overlayNifti.get_fdata()[currentOverlaySlice.get_fdata().astype(bool)],broadcastShape),1)
             #lets mask out the background
             [unique, counts] = np.unique(overlayData, return_counts=True)
             backgroundVal=unique[np.where(np.max(counts)==counts)[0]]
             
-            plt.imshow(np.ma.masked_where(overlayData==backgroundVal,overlayData), cmap='jet', alpha=.75, interpolation='gaussian',vmin=0,vmax=np.nanmax(overlayNifti.get_data()))
+            plt.imshow(np.ma.masked_where(overlayData==backgroundVal,overlayData), cmap='jet', alpha=.75, interpolation='gaussian',vmin=0,vmax=np.nanmax(overlayNifti.get_fdata()))
             curFig=plt.gcf()
             cbaxes = inset_axes(curFig.gca(), width="5%", height="80%", loc=5) 
-            plt.colorbar(cax=cbaxes, ticks=[0.,np.nanmax(overlayNifti.get_data())], orientation='vertical')
+            plt.colorbar(cax=cbaxes, ticks=[0.,np.nanmax(overlayNifti.get_fdata())], orientation='vertical')
             curFig.gca().yaxis.set_ticks_position('left')
             curFig.gca().tick_params( colors='white')
             # we use *2 in order to afford room for the subsequent blended images
@@ -1657,7 +1657,7 @@ def dipyPlotTract(streamlines,refAnatT1=None, tractName=None,endpointColorDensit
         #borrowed from app-
         # compute mean and standard deviation of t1 for brigthness adjustment
         print("setting brightness")
-        t1Data=refAnatT1.get_data()
+        t1Data=refAnatT1.get_fdata()
         mean, std = t1Data[t1Data > 0].mean(), t1Data[t1Data > 0].std()
 
         img_min = 0.5
@@ -1669,7 +1669,7 @@ def dipyPlotTract(streamlines,refAnatT1=None, tractName=None,endpointColorDensit
         
         
         
-        # vol_actor = actor.slicer(refAnatT1.get_data())
+        # vol_actor = actor.slicer(refAnatT1.get_fdata())
         # vol_actor.display(x=0)
         # scene.add(vol_actor)
         print('skipping')
@@ -1739,10 +1739,10 @@ def dipyPlotTract(streamlines,refAnatT1=None, tractName=None,endpointColorDensit
     #no longer hard coding 0,0,0, now using the average endpoint.  Theoretically
     #has to be somewhere in the middle, right?
     kernelNifti=wmaPyTools.roiTools.createSphere(endpointColorDensityKernel, np.mean(allEndpoints,axis=0), refAnatT1)
-    kernelNifti=nib.nifti1.Nifti1Image(kernelNifti.get_data().astype(int), kernelNifti.affine, kernelNifti.header)
+    kernelNifti=nib.nifti1.Nifti1Image(kernelNifti.get_fdata().astype(int), kernelNifti.affine, kernelNifti.header)
     croppedKernel=crop_img(kernelNifti)
    
-    summedDensityMap=ndimage.generic_filter(densityMap,function=np.sum,footprint=croppedKernel.get_data().astype(bool))
+    summedDensityMap=ndimage.generic_filter(densityMap,function=np.sum,footprint=croppedKernel.get_fdata().astype(bool))
 
     for iStreamlines in range(len(streamlines)):
         #A check to make sure you've got room to do this indexing on both sides
@@ -1930,7 +1930,7 @@ def dipyPlotTract_clean(streamlines,refAnatT1=None, tractName=None, parcNifti=No
     #     # #borrowed from app-
     #     # # compute mean and standard deviation of t1 for brigthness adjustment
     #     # print("setting brightness")
-    #     # t1Data=refAnatT1.get_data()
+    #     # t1Data=refAnatT1.get_fdata()
     #     # mean, std = t1Data[t1Data > 0].mean(), t1Data[t1Data > 0].std()
 
     #     # img_min = 0.5
@@ -1942,7 +1942,7 @@ def dipyPlotTract_clean(streamlines,refAnatT1=None, tractName=None, parcNifti=No
         
         
         
-    #     # vol_actor = actor.slicer(refAnatT1.get_data(), refAnatT1.affine, value_range)
+    #     # vol_actor = actor.slicer(refAnatT1.get_fdata(), refAnatT1.affine, value_range)
     #     # vol_actor.display(x=0)
     #     # scene.add(vol_actor)
     #     # print('skipping')
@@ -3375,7 +3375,7 @@ def colorStreamEndpointsFromParc(streamlines,parcNifti,streamColors=None,colorWi
     colorNodeDistance=np.round(colorWindowMM/avgNodeDistance).astype(int)
     
     #get the number of colors required
-    uniqueLabels=np.unique(np.round(parcNifti.get_data()).astype(int))
+    uniqueLabels=np.unique(np.round(parcNifti.get_fdata()).astype(int))
     neededColors=len(uniqueLabels)
     #generate a color selection for these
     endpointsColormap=matplotlib.cm.get_cmap('gist_rainbow')
@@ -3398,7 +3398,7 @@ def colorStreamEndpointsFromParc(streamlines,parcNifti,streamColors=None,colorWi
         streamColors=colorGradientForStreams(streamlines)
     
     #get the endpoint identities
-    M, grouping=utils.connectivity_matrix(streamlines, parcNifti.affine, label_volume=np.round(parcNifti.get_data()).astype(int),
+    M, grouping=utils.connectivity_matrix(streamlines, parcNifti.affine, label_volume=np.round(parcNifti.get_fdata()).astype(int),
                             symmetric=False,
                             return_mapping=True,
                             mapping_as_streamlines=False)
@@ -3665,7 +3665,7 @@ def iteratedTractSubComponentCrossSec(streamlines,atlas,lookupTable,refAnatT1,ou
     
    
     #get the endpoint identities
-    M, grouping=utils.connectivity_matrix(streamlines, renumberedAtlasNifti.affine, label_volume=np.round(renumberedAtlasNifti.get_data()).astype(int),
+    M, grouping=utils.connectivity_matrix(streamlines, renumberedAtlasNifti.affine, label_volume=np.round(renumberedAtlasNifti.get_fdata()).astype(int),
                             return_mapping=True,
                             mapping_as_streamlines=False)
     #get the keys so that you can iterate through them later


### PR DESCRIPTION
Starting with nibabel version 5.0, the get_data() method's deprecation is expired and it raises an error. `nibabel.save()` also raises an ExpiredDeprecation error if you attempt to save an image with `dtype=int`.  After making these changes we are running OK so far with nibabel v5.1.0, but we have not extensively tested wma_pyTools. 

Fixes #11 